### PR TITLE
添加 Thino 和其他平台笔记兼容性支持

### DIFF
--- a/dist/DailyNoteModifier.js
+++ b/dist/DailyNoteModifier.js
@@ -1,0 +1,120 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+exports.__esModule = true;
+exports.DailyNoteModifier = void 0;
+var log = require("@/utils/log");
+/**
+ * Generates a regular expression for matching a header in a daily note.
+ * If the header is already formatted with one or more '#' symbols, it will be used as is.
+ * Otherwise, a single '#' symbol will be added before the header.
+ *
+ * @param header - The header to generate the regular expression for.
+ * @returns The regular expression for matching the header and its content.
+ */
+function generateHeaderRegExp(header) {
+    var formattedHeader = /^#+/.test(header.trim())
+        ? header.trim()
+        : "# ".concat(header.trim());
+    var reg = new RegExp("(".concat(formattedHeader, "[^\n]*)([\\s\\S]*?)(?=\\n#|$)"));
+    return reg;
+}
+var DailyNoteModifier = /** @class */ (function () {
+    function DailyNoteModifier(dailyMemosHeader) {
+        var _this = this;
+        this.dailyMemosHeader = dailyMemosHeader;
+        /**
+         * Daily Notes will be:
+         * ```markdown
+         * contents before
+         * ...
+         *
+         * # The Header
+         * - memos
+         * - memos
+         *
+         * contents after
+         * ```
+         *
+         * @returns modifiedFileContent
+         */
+        this.modifyDailyNote = function (originFileContent, today, fetchedRecordList) {
+            var _a, _b;
+            var header = _this.dailyMemosHeader;
+            var reg = generateHeaderRegExp(header);
+            var regMatch = originFileContent.match(reg);
+            if (!(regMatch === null || regMatch === void 0 ? void 0 : regMatch.length) || regMatch.index === undefined) {
+                log.debug("".concat(regMatch));
+                log.warn("Failed to find header for ".concat(today, ". Please make sure your daily note template is correct."));
+                return;
+            }
+            var localRecordContent = (_a = regMatch[2]) === null || _a === void 0 ? void 0 : _a.trim(); // the memos list
+            var from = regMatch.index + regMatch[1].length + 1; // start of the memos list
+            var to = from + localRecordContent.length + 1; // end of the memos list
+            var prefix = originFileContent.slice(0, from); // contents before the memos list
+            var suffix = originFileContent.slice(to); // contents after the memos list
+            var localRecordList = localRecordContent
+                ? localRecordContent.split(/\n(?=- )/g)
+                : [];
+            // MoeMemos records with timestamp identifier (^timestamp)
+            var moeMemosRecords = {}; // map<timestamp, record>
+            // Thino and other platform memos (without MoeMemos timestamp format)
+            var otherPlatformMemos = [];
+            for (var _i = 0, localRecordList_1 = localRecordList; _i < localRecordList_1.length; _i++) {
+                var record = localRecordList_1[_i];
+                // Check for MoeMemos format (has ^timestamp at the end)
+                var moeMemosMatch = record.match(/.*\^(\d{10})/);
+                // Check for Thino format (starts with bullet point and time)
+                var thinoOrOtherFormatMatch = record.match(/^- \d{1,2}:\d{2}/);
+                if (moeMemosMatch === null || moeMemosMatch === void 0 ? void 0 : moeMemosMatch.length) {
+                    var createdTs = (_b = moeMemosMatch[1]) === null || _b === void 0 ? void 0 : _b.trim();
+                    moeMemosRecords[createdTs] = record;
+                }
+                else if (thinoOrOtherFormatMatch && !(moeMemosMatch === null || moeMemosMatch === void 0 ? void 0 : moeMemosMatch.length)) {
+                    // This is a Thino memo or other platform memo that doesn't have MoeMemos timestamp format
+                    otherPlatformMemos.push(record);
+                }
+            }
+            log.debug("for ".concat(today, "\n\nfetchedRecordList: ").concat(JSON.stringify({
+                from: from,
+                to: to,
+                prefix: prefix,
+                suffix: suffix,
+                localRecordList: localRecordList,
+                moeMemosRecords: moeMemosRecords,
+                otherPlatformMemos: otherPlatformMemos
+            })));
+            // Process MoeMemos records
+            var sortedMoeMemosRecords = Object.entries(__assign(__assign({}, moeMemosRecords), fetchedRecordList))
+                .sort(function (a, b) { return Number(a[0]) - Number(b[0]); })
+                .map(function (item) { return item[1]; });
+            // Combine MoeMemos records with Thino and other platform memos
+            var allMemosCombined = __spreadArray(__spreadArray([], sortedMoeMemosRecords, true), otherPlatformMemos, true).join("\n");
+            var modifiedFileContent = prefix.trim() +
+                "\n\n".concat(allMemosCombined, "\n\n") +
+                suffix.trim() +
+                "\n";
+            return modifiedFileContent;
+        };
+    }
+    return DailyNoteModifier;
+}());
+exports.DailyNoteModifier = DailyNoteModifier;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
 			"DOM",
 			"ES5",
 			"ES6",
-			"ES7"
+			"ES7",
+			"ES2017"
 		],
 		"jsx": "react-jsx"
 	},


### PR DESCRIPTION
## 问题描述
在使用 MoeMemos API 同步笔记时，会覆盖使用 Thino 或其他平台创建的笔记，导致数据丢失。
## 解决方案
修改了 DailyNoteModifier 类，以识别并保留 Thino 和其他平台格式的笔记，确保在同步过程中不会被覆盖。
## 主要更改
1. 添加了 Thino 笔记格式的识别功能
2. 将识别到的非 MoeMemos 格式笔记保存在单独的数组中
3. 在合并笔记时，将 Thino 和其他格式的笔记添加到结果中
## 技术细节
- Thino 笔记通常以 - HH:MM 格式开头（如 - 12:34 内容）
- MoeMemos 笔记带有特定的时间戳标识符（以 ^timestamp 结尾）
- 更新了 TypeScript 配置，添加了 ES2017 支持以使用 Object.entries
## 测试结果
已经针对包含 Thino 笔记和 MoeMemos 笔记的日记文件进行了测试，确认在同步过程中两种格式的笔记都能正确保留。
## 变更影响
这个更改是向后兼容的，不会影响现有用户的使用体验，只会防止 Thino 笔记被覆盖。